### PR TITLE
Trubar 0.3.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,18 +12,18 @@ source:
 build:
   entry_points:
     - trubar = trubar.__main__:main
-  noarch: python
+  skip: True  # [py>38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 0
 
 requirements:
   host:
-    - python {{ python_min }}
-    - setuptools >=40.9.0
+    - python
+    - setuptools
     - wheel
     - pip
   run:
-    - python >={{ python_min }}
+    - python
     - libcst
     - pyyaml
 
@@ -35,7 +35,7 @@ test:
     - trubar --help
   requires:
     - pip
-    - python {{ python_min }}
+    - python
 
 about:
   home: https://github.com/janezd/trubar

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   run:
     - python
     - libcst
-    - pyyaml 
+    - pyyaml
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   entry_points:
     - trubar = trubar.__main__:main
-  skip: True  # [py>38]
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
@@ -42,7 +42,10 @@ about:
   summary: Utility for translation of Python sources
   license: MIT
   license_file: LICENSE
-
+  description: |
+    Trubar is a utility for translation of Python sources. It is designed to be
+    used as a preprocessor for Python code that is to be translated to another
+    language.
 extra:
   recipe-maintainers:
     - janezd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   entry_points:
     - trubar = trubar.__main__:main
-  skip: True  # [py<38]
+  skip: True  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
@@ -41,11 +41,14 @@ about:
   home: https://github.com/janezd/trubar
   summary: Utility for translation of Python sources
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   description: |
     Trubar is a utility for translation of Python sources. It is designed to be
     used as a preprocessor for Python code that is to be translated to another
     language.
+  dev_url: https://github.com/janezd/trubar
+  doc_url: https://github.com/janezd/trubar/tree/master/docs
 extra:
   recipe-maintainers:
     - janezd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   run:
     - python
     - libcst
-    - pyyaml
+    - pyyaml 
 
 test:
   imports:


### PR DESCRIPTION
> ## ☆ Trubar 0.3.4 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-7224) 
[Upstream](https://github.com/janezd/trubar)
> 
> ### Changes
> * Updated dependencies for `run` and `host` 
> * Added skip to python versions less than 3.8
> *  Updated `about` section